### PR TITLE
add argument sink

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -13,4 +13,4 @@
   return array
 }
 
-#let dependent-numbering(style, levels: 1) = n => { numbering(style, ..normalize-length(counter(heading).get(), levels), n) }
+#let dependent-numbering(style, levels: 1) = (..n) => { numbering(style, ..normalize-length(counter(heading).get(), levels), ..n) }

--- a/lib.typ
+++ b/lib.typ
@@ -13,4 +13,4 @@
   return array
 }
 
-#let dependent-numbering(style, levels: 1) = (..n) => { numbering(style, ..normalize-length(counter(heading).get(), levels), ..n) }
+#let dependent-numbering(style, levels: 1) = (..ns) => { numbering(style, ..normalize-length(counter(heading).get(), levels), ..ns) }


### PR DESCRIPTION
fixes #5.

this replaces the single number parameter in `dependent-numbering` with an argument sink, which is passed straight to `numbering`.

nothing should break, since passing a single integer is the same, and passing more used to cause a crash. confirmed that the behavior in example.typ is unchanged.

